### PR TITLE
lib/net/http.rb detect closed connection and reconnect

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -949,3 +949,18 @@ define SDR
   call rb_vmdebug_stack_dump_raw_current()
 end
 
+define rbi
+  if ((LINK_ELEMENT*)$arg0)->type == ISEQ_ELEMENT_LABEL
+    p *(LABEL*)$arg0
+  else
+  if ((LINK_ELEMENT*)$arg0)->type == ISEQ_ELEMENT_INSN
+    p *(INSN*)$arg0
+  else
+  if ((LINK_ELEMENT*)$arg0)->type == ISEQ_ELEMENT_ADJUST
+    p *(ADJUST*)$arg0
+  else
+    print *$arg0
+  end
+  end
+  end
+end

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Tue Nov 10 14:01:59 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
+
+	* hash.c (rb_hash_{le,lt,ge,gt}): new methods, Hash#<=, Hash#<,
+	  Hash#>=, Hash#>, to test if all elements of a hash are also
+	  included in another hash, and vice versa.
+	  [ruby-core:68561] [Feature #10984]
+
 Tue Nov 10 11:25:29 2015  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* time.c (rb_timespec_now): added.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Tue Nov 10 18:42:24 2015  Aleksandrs Ledovskis  <aleksandrs@ledovskis.lv>
+
+	* defs/id.def, parse.y: Switch internal token name to reflect
+	  current form of safe-call operator.  [Fix GH-1090]
+
 Tue Nov 10 18:25:56 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* hash.c (rb_hash_to_proc): use rb_func_proc_new to make light

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+Tue Nov 10 18:23:35 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
+
+	* proc.c (cfunc_proc_t): add room for me.
+
+	* proc.c (cfunc_proc_new): generalise for cfunc proc without env.
+
+	* proc.c (rb_func_proc_new, rb_func_lambda_new): new functions to
+	  make proc/lambda without env from cfunc.
+
 Tue Nov 10 17:32:35 2015  Naohisa Goto  <ngotogenome@gmail.com>
 
 	* bootstraptest/test_fork.rb ([ruby-dev:37934]): :NPROC (RLIMIT_NPROC)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Tue Nov 10 14:34:09 2015  NARUSE, Yui  <naruse@ruby-lang.org>
+
+	* time.c (rb_time_timespec_new): swap utc and localtime
+	  to generate gmt flag by INT_MAX - gmtoff.
+
 Tue Nov 10 14:01:59 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* hash.c (rb_hash_{le,lt,ge,gt}): new methods, Hash#<=, Hash#<,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Tue Nov 10 18:25:56 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
+
+	* hash.c (rb_hash_to_proc): use rb_func_proc_new to make light
+	  weight proc.  [Feature #11653]
+
 Tue Nov 10 18:23:35 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* proc.c (cfunc_proc_t): add room for me.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Tue Nov 10 00:25:41 2015  Kazuki Tsujimoto  <kazuki@callcc.net>
+
+	* gems/bundled_gems: update to power_assert 0.2.6.
+
 Mon Nov  9 21:48:17 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* vm_eval.c (rb_check_funcall_default): split from

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Tue Nov 10 00:36:46 2015  Tanaka Akira  <akr@fsij.org>
+
+	* lib/resolv.rb (Resolv::DNS::Message::MessageEncoder#put_labels):
+	  Prevent overflow of pointer to labels.
+	  Patch by Hannes Georg.  [ruby-core:71248] [Bug #11632]
+
 Tue Nov 10 00:25:41 2015  Kazuki Tsujimoto  <kazuki@callcc.net>
 
 	* gems/bundled_gems: update to power_assert 0.2.6.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+Tue Nov 10 06:17:17 2015  Eric Wong  <e@80x24.org>
+
+	* variable.c (rb_autoload_load): allow recursive calls
+	  [ruby-core:71345] [Bug #11658]
+	* test/ruby/test_autoload.rb (test_autoload_while_autoloading):
+	  new test by: Hiroshi Shirosaki <h.shirosaki@gmail.com>
+	  [ruby-core:71390]
+
 Tue Nov 10 00:36:46 2015  Tanaka Akira  <akr@fsij.org>
 
 	* lib/resolv.rb (Resolv::DNS::Message::MessageEncoder#put_labels):

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Tue Nov 10 17:32:35 2015  Naohisa Goto  <ngotogenome@gmail.com>
+
+	* bootstraptest/test_fork.rb ([ruby-dev:37934]): :NPROC (RLIMIT_NPROC)
+	  is not supported on some platforms (e.g. Solaris 10).
+
 Tue Nov 10 16:57:14 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
 	* hash.c (rb_hash_to_proc): new method Hash#to_proc.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Tue Nov 10 16:57:14 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
+
+	* hash.c (rb_hash_to_proc): new method Hash#to_proc.
+	  [Feature #11653]
+
 Tue Nov 10 14:34:09 2015  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* time.c (rb_time_timespec_new): swap utc and localtime

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Tue Nov 10 11:25:29 2015  NARUSE, Yui  <naruse@ruby-lang.org>
+
+	* time.c (rb_timespec_now): added.
+
+	* time.c (rb_time_timespec_new): added.
+
 Tue Nov 10 06:17:17 2015  Eric Wong  <e@80x24.org>
 
 	* variable.c (rb_autoload_load): allow recursive calls

--- a/NEWS
+++ b/NEWS
@@ -60,6 +60,7 @@ with all sufficient information, see the ChangeLog file.
   * Hash#fetch_values [Feature #10017]
   * Hash#dig [Feature #11643]
   * Hash#<=, Hash#<, Hash#>=, Hash#> [Feature #10984]
+  * Hash#to_proc [Feature #11653]
 
 * IO
 

--- a/NEWS
+++ b/NEWS
@@ -209,6 +209,11 @@ with all sufficient information, see the ChangeLog file.
   class is already defined but its superclass does not match the given
   superclass, as well as definitions in ruby level.
 
+* rb_timespec_now() is added to fetch current datetime as struct timespec.
+
+* rb_time_timespec_new() is added to create a time object with epoch,
+  nanosecond, and UTC/localtime/time offset arguments.
+
 === Build system updates
 
 === Implementation changes

--- a/NEWS
+++ b/NEWS
@@ -59,6 +59,7 @@ with all sufficient information, see the ChangeLog file.
 
   * Hash#fetch_values [Feature #10017]
   * Hash#dig [Feature #11643]
+  * Hash#<=, Hash#<, Hash#>=, Hash#> [Feature #10984]
 
 * IO
 

--- a/benchmark/bm_hash_to_proc.rb
+++ b/benchmark/bm_hash_to_proc.rb
@@ -1,0 +1,9 @@
+h = {}
+
+10000.times do |i|
+  h[i] = nil
+end
+
+5000.times do |i|
+  [i].map(&h)
+end

--- a/bootstraptest/test_fork.rb
+++ b/bootstraptest/test_fork.rb
@@ -24,7 +24,7 @@ assert_finish 10, %q{
 assert_normal_exit(<<'End', '[ruby-dev:37934]')
   main = Thread.current
   Thread.new { sleep 0.01 until main.stop?; Thread.kill main }
-  Process.setrlimit(:NPROC, 1)
+  Process.setrlimit(:NPROC, 1) if defined?(Process::RLIMIT_NPROC)
   fork {}
 End
 

--- a/compile.c
+++ b/compile.c
@@ -2000,6 +2000,18 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 	}
     }
 
+    if (iobj->insn_id == BIN(pop)) {
+	LINK_ELEMENT *prev = iobj->link.prev;
+	if (prev->type == ISEQ_ELEMENT_INSN) {
+	    enum ruby_vminsn_type previ = ((INSN *)prev)->insn_id;
+	    if (previ == BIN(putobject) || previ == BIN(putnil) ||
+		previ == BIN(putself) || previ == BIN(putstring)) {
+		REMOVE_ELEM(prev);
+		REMOVE_ELEM(&iobj->link);
+	    }
+	}
+    }
+
     if (do_tailcallopt && iobj->insn_id == BIN(leave)) {
 	/*
 	 *  send ...

--- a/defs/id.def
+++ b/defs/id.def
@@ -98,7 +98,7 @@ token_ops = %[\
   COLON3        ::
   ANDOP         &&
   OROP          ||
-  DOTQ          &.
+  ANDDOT        &.
 ]
 
 class KeywordError < RuntimeError

--- a/ext/ripper/eventids2.c
+++ b/ext/ripper/eventids2.c
@@ -257,7 +257,7 @@ static const struct token_assoc {
     {tRSHFT,			O(op)},
     {tSTAR,			O(op)},
     {tDSTAR,			O(op)},
-    {tDOTQ,			O(op)},
+    {tANDDOT,			O(op)},
     {tSTRING_BEG,		O(tstring_beg)},
     {tSTRING_CONTENT,		O(tstring_content)},
     {tSTRING_DBEG,		O(embexpr_beg)},

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -1,4 +1,4 @@
-power_assert 0.2.5
+power_assert 0.2.6
 test-unit 3.1.5
 minitest 5.8.2
 rake 10.4.2

--- a/hash.c
+++ b/hash.c
@@ -2766,6 +2766,18 @@ rb_hash_gt(VALUE hash, VALUE other)
     return hash_le(other, hash);
 }
 
+static VALUE
+hash_proc_call(VALUE key, VALUE hash, int argc, const VALUE *argv, VALUE passed_proc)
+{
+    return rb_hash_aref(hash, key);
+}
+
+static VALUE
+rb_hash_to_proc(VALUE hash)
+{
+    return rb_proc_new(hash_proc_call, hash);
+}
+
 static int path_tainted = -1;
 
 static char **origenviron;
@@ -4132,6 +4144,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash,"to_a", rb_hash_to_a, 0);
     rb_define_method(rb_cHash,"inspect", rb_hash_inspect, 0);
     rb_define_alias(rb_cHash, "to_s", "inspect");
+    rb_define_method(rb_cHash,"to_proc", rb_hash_to_proc, 0);
 
     rb_define_method(rb_cHash,"==", rb_hash_equal, 1);
     rb_define_method(rb_cHash,"[]", rb_hash_aref, 1);

--- a/hash.c
+++ b/hash.c
@@ -2769,13 +2769,14 @@ rb_hash_gt(VALUE hash, VALUE other)
 static VALUE
 hash_proc_call(VALUE key, VALUE hash, int argc, const VALUE *argv, VALUE passed_proc)
 {
-    return rb_hash_aref(hash, key);
+    rb_check_arity(argc, 1, 1);
+    return rb_hash_aref(hash, *argv);
 }
 
 static VALUE
 rb_hash_to_proc(VALUE hash)
 {
-    return rb_proc_new(hash_proc_call, hash);
+    return rb_func_proc_new(hash_proc_call, hash);
 }
 
 static int path_tainted = -1;

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -919,8 +919,10 @@ VALUE rb_mutex_unlock(VALUE mutex);
 VALUE rb_mutex_sleep(VALUE self, VALUE timeout);
 VALUE rb_mutex_synchronize(VALUE mutex, VALUE (*func)(VALUE arg), VALUE arg);
 /* time.c */
+void rb_timespec_now(struct timespec *);
 VALUE rb_time_new(time_t, long);
 VALUE rb_time_nano_new(time_t, long);
+VALUE rb_time_timespec_new(const struct timespec *, int);
 VALUE rb_time_num_new(VALUE, VALUE);
 struct timeval rb_time_interval(VALUE num);
 struct timeval rb_time_timeval(VALUE time);

--- a/internal.h
+++ b/internal.h
@@ -1013,6 +1013,8 @@ ID rb_id_attrget(ID id);
 VALUE rb_proc_location(VALUE self);
 st_index_t rb_hash_proc(st_index_t hash, VALUE proc);
 int rb_block_arity(void);
+VALUE rb_func_proc_new(rb_block_call_func_t func, VALUE val);
+VALUE rb_func_lambda_new(rb_block_call_func_t func, VALUE val);
 
 /* process.c */
 #define RB_MAX_GROUPS (65536)

--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -582,7 +582,7 @@ module DRb
       begin
         str = soc.read(sz)
       rescue
-        raise(DRbConnError, $!.message + " peer: #{soc.peeraddr[2]}:#{soc.peeraddr[1]}, sz: #{sz}", $!.backtrace)
+        raise(DRbConnError, $!.message, $!.backtrace)
       end
       raise(DRbConnError, 'connection closed') if str.nil?
       raise(DRbConnError, 'premature marshal format(can\'t read)') if str.size < sz

--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -1477,7 +1477,9 @@ class Resolv
               self.put_pack("n", 0xc000 | idx)
               return
             else
-              @names[domain] = @data.length
+              if @data.length < 0x4000
+                @names[domain] = @data.length
+              end
               self.put_label(d[i])
             end
           }

--- a/parse.y
+++ b/parse.y
@@ -371,7 +371,7 @@ static int parser_yyerror(struct parser_params*, const char*);
 #define ruby_coverage		(parser->coverage)
 #endif
 
-#define CALL_Q_P(q) ((q) == tDOTQ)
+#define CALL_Q_P(q) ((q) == tANDDOT)
 #define NODE_CALL_Q(q) (CALL_Q_P(q) ? NODE_QCALL : NODE_CALL)
 #define NEW_QCALL(q,r,m,a) NEW_NODE(NODE_CALL_Q(q),r,m,a)
 
@@ -875,7 +875,7 @@ static void token_info_pop(struct parser_params*, const char *token, size_t len)
 %token tASET		RUBY_TOKEN(ASET)   "[]="
 %token tLSHFT		RUBY_TOKEN(LSHFT)  "<<"
 %token tRSHFT		RUBY_TOKEN(RSHFT)  ">>"
-%token tDOTQ		RUBY_TOKEN(DOTQ)   "&."
+%token tANDDOT		RUBY_TOKEN(ANDDOT) "&."
 %token tCOLON2		"::"
 %token tCOLON3		":: at EXPR_BEG"
 %token <id> tOP_ASGN	/* +=, -=  etc. */
@@ -5117,12 +5117,12 @@ call_op 	: '.'
 		        $$ = ripper_id2sym('.');
 		    %*/
 		    }
-		| tDOTQ
+		| tANDDOT
 		    {
 		    /*%%%*/
-			$$ = tDOTQ;
+			$$ = tANDDOT;
 		    /*%
-		        $$ = ripper_id2sym(idDOTQ);
+		        $$ = ripper_id2sym(idANDDOT);
 		    %*/
 		    }
 		;
@@ -8278,7 +8278,7 @@ parser_yylex(struct parser_params *parser)
 	}
 	else if (c == '.') {
 	    lex_state = EXPR_DOT;
-	    return tDOTQ;
+	    return tANDDOT;
 	}
 	pushback(c);
 	if (IS_SPCARG(c)) {

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -880,6 +880,23 @@ class TestNetHTTPKeepAlive < Test::Unit::TestCase
     }
   end
 
+  def test_server_closed_connection_auto_reconnect
+    start {|http|
+      res = http.get('/')
+      http.keep_alive_timeout = 5
+      assert_kind_of Net::HTTPResponse, res
+      assert_kind_of String, res.body
+      sleep 1.5
+      assert_nothing_raised {
+        # Net::HTTP should detect the closed connection before attempting the
+        # request, since post requests cannot be retried.
+        res = http.post('/', 'query=foo')
+      }
+      assert_kind_of Net::HTTPResponse, res
+      assert_kind_of String, res.body
+    }
+  end
+
   def test_keep_alive_get_auto_retry
     start {|http|
       res = http.get('/')

--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -197,4 +197,21 @@ class TestResolvDNS < Test::Unit::TestCase
     expected = (['0'] * 32 + ['ip6', 'arpa']).map {|label| Resolv::DNS::Label::Str.new(label) }
     assert_equal(expected, labels)
   end
+
+  def test_too_big_label_address
+    n = 2000
+    m = Resolv::DNS::Message::MessageEncoder.new {|msg|
+      2.times {
+        n.times {|i| msg.put_labels(["foo#{i}"]) }
+      }
+    }
+    Resolv::DNS::Message::MessageDecoder.new(m.to_s) {|msg|
+      2.times {
+        n.times {|i|
+          assert_equal(["foo#{i}"], msg.get_labels.map {|label| label.to_s })
+        }
+      }
+    }
+    assert_operator(2**14, :<, m.to_s.length)
+  end
 end

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1333,6 +1333,16 @@ class TestHash < Test::Unit::TestCase
     assert_not_operator(h2, :>, h2)
   end
 
+  def test_to_proc
+    h = {
+      1 => 10,
+      2 => 20,
+      3 => 30,
+    }
+
+    assert_equal([10, 20, 30], [1, 2, 3].map(&h))
+  end
+
   class TestSubHash < TestHash
     class SubHash < Hash
       def reject(*)

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1308,6 +1308,31 @@ class TestHash < Test::Unit::TestCase
     assert_nil(h.dig(:c, 1))
   end
 
+  def test_cmp
+    h1 = {a:1, b:2}
+    h2 = {a:1, b:2, c:3}
+
+    assert_operator(h1, :<=, h1)
+    assert_operator(h1, :<=, h2)
+    assert_not_operator(h2, :<=, h1)
+    assert_operator(h2, :<=, h2)
+
+    assert_operator(h1, :>=, h1)
+    assert_not_operator(h1, :>=, h2)
+    assert_operator(h2, :>=, h1)
+    assert_operator(h2, :>=, h2)
+
+    assert_not_operator(h1, :<, h1)
+    assert_operator(h1, :<, h2)
+    assert_not_operator(h2, :<, h1)
+    assert_not_operator(h2, :<, h2)
+
+    assert_not_operator(h1, :>, h1)
+    assert_not_operator(h1, :>, h2)
+    assert_operator(h2, :>, h1)
+    assert_not_operator(h2, :>, h2)
+  end
+
   class TestSubHash < TestHash
     class SubHash < Hash
       def reject(*)

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1494,6 +1494,35 @@ class TestRefinement < Test::Unit::TestCase
     INPUT
   end
 
+  def test_reopen_refinement_module
+    assert_separately([], <<-"end;")
+      $VERBOSE = nil
+      class C
+      end
+
+      module R
+        refine C do
+          def m
+            :foo
+          end
+        end
+      end
+
+      using R
+      assert_equal(:foo, C.new.m)
+
+      module R
+        refine C do
+          def m
+            :bar
+          end
+        end
+      end
+
+      assert_equal(:bar, C.new.m)
+    end;
+  end
+
   private
 
   def eval_using(mod, s)

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1495,6 +1495,7 @@ class TestRefinement < Test::Unit::TestCase
   end
 
   def test_reopen_refinement_module
+    flag = false
     assert_separately([], <<-"end;")
       $VERBOSE = nil
       class C
@@ -1521,6 +1522,11 @@ class TestRefinement < Test::Unit::TestCase
 
       assert_equal(:bar, C.new.m, "[ruby-core:71423] [Bug #11672]")
     end;
+    flag = true
+  rescue MiniTest::Assertion
+    skip 'expected to fail'
+  ensure
+    raise MiniTest::Assertion, 'this test is expected to fail' if flag
   end
 
   private

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1519,7 +1519,7 @@ class TestRefinement < Test::Unit::TestCase
         end
       end
 
-      assert_equal(:bar, C.new.m)
+      assert_equal(:bar, C.new.m, "[ruby-core:71423] [Bug #11672]")
     end;
   end
 

--- a/time.c
+++ b/time.c
@@ -1892,6 +1892,25 @@ timew2timespec_exact(wideval_t timew, struct timespec *ts)
     return ts;
 }
 
+void
+rb_timespec_now(struct timespec *ts)
+{
+#ifdef HAVE_CLOCK_GETTIME
+    if (clock_gettime(CLOCK_REALTIME, ts) == -1) {
+	rb_sys_fail("clock_gettime");
+    }
+#else
+    {
+        struct timeval tv;
+        if (gettimeofday(&tv, 0) < 0) {
+            rb_sys_fail("gettimeofday");
+        }
+        ts->tv_sec = tv.tv_sec;
+        ts->tv_nsec = tv.tv_usec * 1000;
+    }
+#endif
+}
+
 static VALUE
 time_init_0(VALUE time)
 {
@@ -1903,20 +1922,7 @@ time_init_0(VALUE time)
     tobj->gmt = 0;
     tobj->tm_got=0;
     tobj->timew = WINT2FIXWV(0);
-#ifdef HAVE_CLOCK_GETTIME
-    if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
-	rb_sys_fail("clock_gettime");
-    }
-#else
-    {
-        struct timeval tv;
-        if (gettimeofday(&tv, 0) < 0) {
-            rb_sys_fail("gettimeofday");
-        }
-        ts.tv_sec = tv.tv_sec;
-        ts.tv_nsec = tv.tv_usec * 1000;
-    }
-#endif
+    rb_timespec_now(&ts);
     tobj->timew = timespec2timew(&ts);
 
     return time;
@@ -2299,10 +2305,39 @@ rb_time_new(time_t sec, long usec)
     return time_new_timew(rb_cTime, timew);
 }
 
+/* returns localtime time object */
 VALUE
 rb_time_nano_new(time_t sec, long nsec)
 {
     return time_new_timew(rb_cTime, nsec2timew(sec, nsec));
+}
+
+/**
+ * Returns a time object with UTC/localtime/fixed offset
+ *
+ * offset is -86400 < fixoff < 86400 or INT_MAX (UTC) or INT_MAX-1 (localtime)
+ */
+VALUE
+rb_time_timespec_new(const struct timespec *ts, int offset)
+{
+    struct time_object *tobj;
+    VALUE time = time_new_timew(rb_cTime, nsec2timew(ts->tv_sec, ts->tv_nsec));
+
+    if (-86400 < offset && offset <  86400) { /* fixoff */
+	GetTimeval(time, tobj);
+	TIME_SET_FIXOFF(tobj, INT2FIX(offset));
+    }
+    else if (offset == INT_MAX) { /* UTC */
+	GetTimeval(time, tobj);
+	TIME_SET_UTC(tobj);
+    }
+    else if (offset == INT_MAX-1) { /* localtime */
+    }
+    else {
+	rb_raise(rb_eArgError, "utc_offset out of range");
+    }
+
+    return time;
 }
 
 VALUE

--- a/time.c
+++ b/time.c
@@ -1747,7 +1747,7 @@ localtimew(wideval_t timew, struct vtm *result)
 PACKED_STRUCT_UNALIGNED(struct time_object {
     wideval_t timew; /* time_t value * TIME_SCALE.  possibly Rational. */
     struct vtm vtm;
-    uint8_t gmt:3; /* 0:utc 1:localtime 2:fixoff 3:init */
+    uint8_t gmt:3; /* 0:localtime 1:utc 2:fixoff 3:init */
     uint8_t tm_got:1;
 });
 

--- a/time.c
+++ b/time.c
@@ -2315,7 +2315,7 @@ rb_time_nano_new(time_t sec, long nsec)
 /**
  * Returns a time object with UTC/localtime/fixed offset
  *
- * offset is -86400 < fixoff < 86400 or INT_MAX (UTC) or INT_MAX-1 (localtime)
+ * offset is -86400 < fixoff < 86400 or INT_MAX (localtime) or INT_MAX-1 (utc)
  */
 VALUE
 rb_time_timespec_new(const struct timespec *ts, int offset)
@@ -2327,11 +2327,11 @@ rb_time_timespec_new(const struct timespec *ts, int offset)
 	GetTimeval(time, tobj);
 	TIME_SET_FIXOFF(tobj, INT2FIX(offset));
     }
-    else if (offset == INT_MAX) { /* UTC */
+    else if (offset == INT_MAX) { /* localtime */
+    }
+    else if (offset == INT_MAX-1) { /* UTC */
 	GetTimeval(time, tobj);
 	TIME_SET_UTC(tobj);
-    }
-    else if (offset == INT_MAX-1) { /* localtime */
     }
     else {
 	rb_raise(rb_eArgError, "utc_offset out of range");

--- a/variable.c
+++ b/variable.c
@@ -2179,6 +2179,9 @@ rb_autoload_load(VALUE mod, ID id)
 	 */
 	list_head_init(&state.waitq.head);
     }
+    else if (state.thread == ele->state->thread) {
+	return Qfalse;
+    }
     else {
 	list_add_tail(&ele->state->waitq.head, &state.waitq.node);
 	/*

--- a/version.h
+++ b/version.h
@@ -1,10 +1,10 @@
 #define RUBY_VERSION "2.3.0"
-#define RUBY_RELEASE_DATE "2015-11-09"
+#define RUBY_RELEASE_DATE "2015-11-10"
 #define RUBY_PATCHLEVEL -1
 
 #define RUBY_RELEASE_YEAR 2015
 #define RUBY_RELEASE_MONTH 11
-#define RUBY_RELEASE_DAY 9
+#define RUBY_RELEASE_DAY 10
 
 #include "ruby/version.h"
 


### PR DESCRIPTION
If the server closes a keep-alive http connection, the client socket reaches EOF.
To avoid an EOFError, detect the closed connection and reconnect.

Added test to ensure HTTP#post succeeds even if the keep-alive-connection has been closed by the server.
